### PR TITLE
Fix redundant to_json call

### DIFF
--- a/godot-scripts/ReferenceCollector.gd
+++ b/godot-scripts/ReferenceCollector.gd
@@ -78,7 +78,7 @@ func save_text(path := "", content := "") -> void:
 	var file := File.new()
 	
 	file.open(path, File.WRITE)
-	file.store_string(to_json(content))
+	file.store_string(content)
 	file.close()
 	print("Saved data to %s" % path)
 


### PR DESCRIPTION
The content string is already a json string from the to_json call in _run. The redundant call resulted in the array being wrapped in a string, and all quotation marks being backslash escaped inside.