### PR TITLE
Fix bug in CLI tool regarding dist within dist

### DIFF
--- a/windows.bat
+++ b/windows.bat
@@ -51,7 +51,14 @@ IF NOT EXIST dist (
 	EXIT /B -1
 )
 
-:: Puts the resulting distribution result into the project folder.
-move /Y dist %project_name%\dist
+IF EXIST %project_name%\dist (
+	:: Move all files in dist into project name dist
+	erase /Q %project_name%\dist
+	move /Y dist\* %project_name%\dist >nul
+	rmdir /q /s dist
+) ELSE (
+	:: Puts the resulting distribution result into the project folder.
+	move /Y dist %project_name%\dist
+)
 
 echo Done. Output now in %~dp0%project_name%\dist


### PR DESCRIPTION
When the /dist directory already existed, the new dist was moved into the old one instead of overwriting it.

*Because batch is kind of poopy*