### PR TITLE
Fix bugs, prettify JSON, and improve batch script

### DIFF
--- a/gdscript-docs-maker/__main__.py
+++ b/gdscript-docs-maker/__main__.py
@@ -15,7 +15,7 @@ from .modules.config import LOGGER, LOG_LEVELS
 
 def main():
     args: Namespace = command_line.parse()
-    logging.basicConfig(level=LOG_LEVEL[min(args.verbose, len(LOG_LEVELS) - 1)])
+    logging.basicConfig(level=LOG_LEVELS[min(args.verbose, len(LOG_LEVELS) - 1)])
     json_files: List[str] = [f for f in args.files if f.lower().endswith(".json")]
     LOGGER.info("Processing JSON files: {}".format(json_files))
     for f in json_files:

--- a/gdscript-docs-maker/modules/gdscript_objects.py
+++ b/gdscript-docs-maker/modules/gdscript_objects.py
@@ -126,11 +126,11 @@ def get_tags(description: str) -> Tuple[str, List[str]]:
     lines: List[str] = description.split("\n")
     description_trimmed = []
     for index, line in enumerate(lines):
-        line = line.strip().lower()
-        if not line.startswith("tags:"):
+        tag_line: str = line.strip().lower()
+        if not tag_line.startswith("tags:"):
             description_trimmed.append(line)
             continue
-        tags = line.replace("tags:", "", 1).split(",")
+        tags = tag_line.replace("tags:", "", 1).split(",")
         tags = list(map(lambda t: t.strip(), tags))
     return "\n".join(description_trimmed), tags
 

--- a/generate_reference.bat
+++ b/generate_reference.bat
@@ -5,9 +5,25 @@
 
 :: Configuration: Modify ReferenceCollectorCLI.gd with paths relative to the project's res://
 
-IF NOT EXIST "%1\project.godot" (
-	echo Godot project not found at %~dp1project.godot
-	EXIT /B -1	
+where /q godot*
+if ERRORLEVEL 1 (
+	ECHO "Godot is missing from the PATH environment."
+	EXIT /B
+)
+
+where /q python*
+IF ERRORLEVEL 1 (
+	ECHO "Python is missing from the PATH environment."
+	EXIT /B
+)
+
+for /f "delims=" %%F in ('where godot*') do set godot=%%F
+
+set project_path=%1
+
+IF NOT EXIST "%project_path%\project.godot" (
+	echo Could not find a project.godot in %project_path%. This program needs a Godot project to work.
+	EXIT /B
 )
 
 IF [%2] == [] (
@@ -16,51 +32,63 @@ IF [%2] == [] (
 	set project_name=%2
 )
 
-IF NOT EXIST %project_name% (
+IF NOT EXIST "%project_name%" (
 	:: Creates the directory with project name.
-	mkdir %project_name%
+	mkdir "%project_name%"
 )
 
-echo Copying collector
+set gdscript_path=godot-scripts
+set gdscript_1=ReferenceCollectorCLI.gd
+set gdscript_2=Collector.gd
+
 :: Copies the CLI gdscript to the project location so godot can find it in res://
-copy /Y godot-scripts\ReferenceCollectorCLI.gd %1\ReferenceCollectorCLI.gd
-copy /Y godot-scripts\Collector.gd %1\Collector.gd
+copy /Y "%gdscript_path%\%gdscript_1%" "%project_path%\ReferenceCollectorCLI.gd" >nul
+copy /Y "%gdscript_path%\%gdscript_2%" "%project_path%\Collector.gd" >nul
 
-echo Running godot
+echo Generating reference...
 :: Runs godot in editor mode, runs the script ReferenceCollectorCLI, and quits
-godot -e -q -s --no-window --path %1 ReferenceCollectorCLI.gd >nul
+%godot% -e -q -s --no-window --path "%project_path%" ReferenceCollectorCLI.gd >nul
 
-echo Cleaning up
 :: Removes the CLI tool from the project.
-erase /Q %1\ReferenceCollectorCLI.gd
-erase /Q %1\Collector.gd
+erase /Q "%project_path%\ReferenceCollectorCLI.gd"
+erase /Q "%project_path%\Collector.gd"
 
-IF NOT EXIST %1\reference.json (
-	echo Collector failed - Json reference file not created
-	EXIT /B -1
+IF NOT EXIST "%project_path%\reference.json" (
+	echo There was an error generating the reference from godot.
+	EXIT /B
+) else (
+	echo Done.
 )
 
-echo Preparing for distribution
-:: Moves the dumped json file.
-move /Y %1\reference.json %project_name%\reference.json
+:: Empty current version of dist if it exists
+if EXIST dist (
+	erase /Q dist
+)
 
+echo Generating markdown files in %project_name%
 :: Runs the markdown creator.
 :: TODO: Skip the moving by having the python script output dist into the project folder
-python -m gdscript-docs-maker %project_name%/reference.json
+python -m gdscript-docs-maker "%project_path%/reference.json"
 
 IF NOT EXIST dist (
+	goto :PythonError
+) else (
+	for /F %%i in ('dir /b "dist\*.*"') do (
+		goto :Success
+	)
+	
+	:PythonError
 	echo Python module failed to create markdown distribution
-	EXIT /B -1
+	EXIT /B
 )
 
-IF EXIST %project_name%\dist (
+:Success
+IF EXIST "%project_name%" (
 	:: Move all files in dist into project name dist
-	erase /Q %project_name%\dist
-	move /Y dist\* %project_name%\dist >nul
+	erase /Q "%project_name%"
+	move /Y dist\* "%project_name%" >nul
 	rmdir /q /s dist
 ) ELSE (
 	:: Puts the resulting distribution result into the project folder.
-	move /Y dist %project_name%\dist
+	move /Y dist "%project_name%"
 )
-
-echo Done. Output now in %~dp0%project_name%\dist

--- a/godot-scripts/Collector.gd
+++ b/godot-scripts/Collector.gd
@@ -76,3 +76,7 @@ func get_reference(files := PoolStringArray()) -> Array:
 		var symbols: Dictionary = workspace.generate_script_api(file)
 		reference.append(symbols)
 	return reference
+
+
+func print_pretty_json(reference: Array) -> String:
+	return JSON.print(reference, "  ")

--- a/godot-scripts/README.md
+++ b/godot-scripts/README.md
@@ -8,14 +8,18 @@ You can find more detailed instructions inside the GDScript code itself.
 
 ## CLI version ##
 
-An alternative to running the EditorScript is to use a command-line version of the tool found in the root of the repository. It requires `godot` to be in the PATH environment variable.
+An alternative to running the EditorScript is to use a command-line version of the tool found in the root of the repository. It requires Godot to be in the PATH environment variable.
 
 - **Windows**
-
-```batch
-windows.bat path/to/project project-name
+```bash
+generate_reference path\to\project project-name
+```
+- **Unix**
+```bash
+sh generate_reference.sh path/to/project project-name
 ```
 
-`project-name` is optional - it will default to "project", and is the folder the distribution will be output into.
+- The first parameter should be a path to a directory that contains a `project.godot` file.
+- `project-name` is the folder the distribution will be output into
 
 This script will copy the collector CLI script, run godot and quit, run the python module, and output the results into `project-name`.

--- a/godot-scripts/ReferenceCollector.gd
+++ b/godot-scripts/ReferenceCollector.gd
@@ -26,5 +26,5 @@ func _run() -> void:
 	var files := PoolStringArray()
 	for dirpath in directories:
 		files.append_array(Collector.find_files(dirpath, patterns, is_recursive))
-	var json := to_json(Collector.get_reference(files))
+	var json := Collector.print_pretty_json(Collector.get_reference(files))
 	Collector.save_text(save_path, json)

--- a/godot-scripts/ReferenceCollectorCLI.gd
+++ b/godot-scripts/ReferenceCollectorCLI.gd
@@ -16,5 +16,5 @@ func _init() -> void:
 	var files := PoolStringArray()
 	for dirpath in directories:
 		files.append_array(Collector.find_files(dirpath, patterns, is_recursive))
-	var json := to_json(Collector.get_reference(files))
+	var json: String = Collector.print_pretty_json(Collector.get_reference(files))
 	Collector.save_text("res://reference.json", json)


### PR DESCRIPTION
- The batch script is made a little bit more robust, and outputs more in line with what the shell script outputs. The README was also improved to reference files correctly.
- After some testing of the scripts, a couple bugs in the python code were fix. Namely, all comments were forced lower case, and a __main__ crash because of a typo.
- If we intend on using the JSON file to hold additional data that's not in the source, it should be human readable and editable. Instead of the generic `to_json`, the JSON class was used to set a two space indent.

EDIT: Just noticed that the merge JSON intends on doing formatting once finished. Still issuing the fix for people who want to use the ReferenceCollector.gd option for their own purposes, however.