### PR TITLE
Add format and author options to generate_reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ Flags:
 
 -h/--help             -- Display this help message.
 -o/--output-directory -- directory path to output the documentation into.
+-f/--format        -- File format, default is markdown, but you can indicate hugo
+-a/--author        -- Author which will writen in markdown file for hugo format
 ```
 
 To use them:

--- a/README.md
+++ b/README.md
@@ -101,8 +101,8 @@ Flags:
 
 -h/--help             -- Display this help message.
 -o/--output-directory -- directory path to output the documentation into.
--f/--format        -- File format, default is markdown, but you can indicate hugo
--a/--author        -- Author which will writen in markdown file for hugo format
+-f/--format           -- Either `markdown` or `hugo`. If `hugo`, the output document includes a TOML front-matter at the top. Default: `markdown`.
+-a/--author           -- If --format is `hugo`, controls the author property in the TOML front-matter.
 ```
 
 To use them:

--- a/generate_reference
+++ b/generate_reference
@@ -5,7 +5,7 @@ project_directory="$1"
 output_directory="export"
 directories_override=""
 format="markdown"
-author="developper"
+author="developer"
 
 echo_help() {
 	echo '
@@ -24,8 +24,8 @@ echo_help() {
     -h/--help             -- Display this help message.
     -o/--output-directory -- directory path to output the documentation into.
     -d/--directory        -- Name of a directory to find files and generate the code reference in the Godot
-    -f/--format        -- File format, default is markdown, but you can indicate hugo
-    -a/--author        -- Author which will writen in markdown file for hugo format
+    -f/--format           -- Either `markdown` or `hugo`. If `hugo`, the output document includes a TOML front-matter at the top. Default: `markdown`.
+    -a/--author           -- If --format is `hugo`, controls the author property in the TOML front-matter.
 
      project. You can use the option multiple times to generate a reference for multiple directories.
 

--- a/generate_reference
+++ b/generate_reference
@@ -4,6 +4,8 @@ set -x
 project_directory="$1"
 output_directory="export"
 directories_override=""
+format="markdown"
+author="developper"
 
 echo_help() {
 	echo '
@@ -22,6 +24,9 @@ echo_help() {
     -h/--help             -- Display this help message.
     -o/--output-directory -- directory path to output the documentation into.
     -d/--directory        -- Name of a directory to find files and generate the code reference in the Godot
+    -f/--format        -- File format, default is markdown, but you can indicate hugo
+    -a/--author        -- Author which will writen in markdown file for hugo format
+
      project. You can use the option multiple times to generate a reference for multiple directories.
 
     Usage example:
@@ -34,7 +39,7 @@ echo_help() {
 	exit 0
 }
 
-arguments=$(getopt --name "generate_reference" -o "h,o:,d:" -l "help,output-directory:,directories:" -- "$@")
+arguments=$(getopt --name "generate_reference" -o "h,o:,d:,f:,a:" -l "help,output-directory:,directories:" -- "$@")
 eval set -- "$arguments"
 while true; do
 	case "$1" in
@@ -50,6 +55,15 @@ while true; do
 		directories_override="$directories_override $2"
 		shift 2
 		;;
+	-f | --format)
+		format=$2
+		shift 2
+		;;
+	-a | --author)
+		author=$2
+		shift 2
+		;;
+		
 	--)
 		shift
 		break
@@ -114,4 +128,4 @@ rm -v "$godot_project_dir/$(basename $path_collector)"
 echo "Generating markdown files in $output_directory"
 ! test -d "$output_directory" && mkdir -v "$output_directory"
 
-python3 -m gdscript_docs_maker "$godot_project_dir/reference.json" --path $output_directory
+python3 -m gdscript_docs_maker "$godot_project_dir/reference.json" --path $output_directory --format $format --author $author


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [X] The commit message follows our guidelines.
- For bug fixes and features:
    - [X] You tested the changes.
    - [X] You updated the docs or changelog.


Related issue (if applicable): 

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**
Only add 2 options to indicate format and author to the python module

**Does this PR introduce a breaking change?**
no

## New feature or change ##

**What is the current behavior?** 
We need to use the entire python command to do this

**What is the new behavior?**
you can use ./generate as usual with parameter -f hugo -a mika for exemple

**Other information**
no
