### PR TITLE
Add support for constants

### DIFF
--- a/gdscript_docs_maker/modules/convert_to_markdown.py
+++ b/gdscript_docs_maker/modules/convert_to_markdown.py
@@ -101,6 +101,7 @@ def _write_class(
         markdown += make_heading(gdscript.name, heading_level)
     for attribute, title in [
         ("enums", "Enumerations"),
+        ("constants", "Constants Descriptions"),
         ("members", "Property Descriptions"),
         ("functions", "Method Descriptions"),
     ]:

--- a/gdscript_docs_maker/modules/gdscript_objects.py
+++ b/gdscript_docs_maker/modules/gdscript_objects.py
@@ -237,6 +237,25 @@ class Member(Element):
             data["getter"],
         )
 
+@dataclass
+class Constant(Element):
+    """Represents a constant"""
+
+    type: str
+    default_value: str
+
+    def summarize(self) -> List[str]:
+        return [self.type, self.name]
+
+    @staticmethod
+    def from_dict(data: dict) -> "Constant":
+        return Constant(
+            data["signature"],
+            data["name"],
+            data["description"],
+            data["data_type"],
+            data["value"],
+        )
 
 @dataclass
 class GDScriptClass:
@@ -246,6 +265,7 @@ class GDScriptClass:
     path: str
     functions: List[Function]
     members: List[Member]
+    constants: List[Constant]
     signals: List[Signal]
     enums: List[Enumeration]
     sub_classes: List["GDScriptClass"]
@@ -270,6 +290,7 @@ class GDScriptClass:
             _get_functions(data["methods"])
             + _get_functions(data["static_functions"], is_static=True),
             _get_members(data["members"]),
+            _get_constants(data["constants"]),
             _get_signals(data["signals"]),
             [
                 Enumeration.from_dict(entry)
@@ -365,4 +386,9 @@ inclusion, and private methods."""
 def _get_members(data: List[dict]) -> List[Member]:
     return [
         Member.from_dict(entry) for entry in data if not entry["name"].startswith("_")
+    ]
+
+def _get_constants(data: List[dict]) -> List[Constant]:
+    return [
+        Constant.from_dict(entry) for entry in data if not entry["name"].startswith("_") and not entry["data_type"] == "Dictionary"
     ]

--- a/gdscript_docs_maker/modules/gdscript_objects.py
+++ b/gdscript_docs_maker/modules/gdscript_objects.py
@@ -6,6 +6,7 @@ import re
 from dataclasses import dataclass
 from enum import Enum
 from typing import List, Tuple
+from operator import itemgetter
 
 from .make_markdown import make_bold, make_code_inline, make_list, surround_with_html
 from .utils import build_re_pattern
@@ -389,6 +390,7 @@ def _get_members(data: List[dict]) -> List[Member]:
     ]
 
 def _get_constants(data: List[dict]) -> List[Constant]:
+    sorted_data = sorted(data, key=itemgetter('name'))
     return [
-        Constant.from_dict(entry) for entry in data if not entry["name"].startswith("_") and not entry["data_type"] == "Dictionary"
+        Constant.from_dict(entry) for entry in sorted_data if not entry["name"].startswith("_") and not entry["data_type"] == "Dictionary"
     ]

--- a/gdscript_docs_maker/modules/gdscript_objects.py
+++ b/gdscript_docs_maker/modules/gdscript_objects.py
@@ -297,6 +297,7 @@ class GDScriptClass:
                 Enumeration.from_dict(entry)
                 for entry in data["constants"]
                 if entry["data_type"] == "Dictionary"
+                and all(isinstance(v, int) for v in entry["value"].values())
                 and not entry["name"].startswith("_")
             ],
             [GDScriptClass.from_dict(data) for data in data["sub_classes"]],
@@ -392,5 +393,9 @@ def _get_members(data: List[dict]) -> List[Member]:
 def _get_constants(data: List[dict]) -> List[Constant]:
     sorted_data = sorted(data, key=itemgetter('name'))
     return [
-        Constant.from_dict(entry) for entry in sorted_data if not entry["name"].startswith("_") and not entry["data_type"] == "Dictionary"
+        Constant.from_dict(entry) for entry in sorted_data
+        if not entry["name"].startswith("_")
+        and (not entry["data_type"] == "Dictionary"
+            or (entry["data_type"] == "Dictionary"
+                and not all(isinstance(v, int) for v in entry["value"].values())))
     ]


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.
- For bug fixes and features:
    - [x] You tested the changes.
    - [ ] You updated the docs or changelog.


Closes #70 

Unfortunately I couldn't find any commit message guideline, and I didn't want to update the version in the official changelog.

I have tested the change in my own repo and it seems to work fine (see https://github.com/db0/godot-card-gaming/wiki/ScriptTask or https://github.com/db0/godot-card-gaming/wiki/CardFrameworkConfiguration

Unfortunately due to the way references.json is not marking enumerations, but rather list everything as constant, I stayed with your existing approach and marked all dictionary constants as enums (even though they may not be). But non-dictionary constants should be documented correctly.

One thing I'd like you to take a look is in the Constant class: Initially I did not have the `default_value: str` definition, but then python was failing because it was claiming __init__() expected 5 vars but 6 were provided. I could not find what the 6th variable was supposed to be and unfortunately your python skill is quite a bit more advanced than mine so it was fairly difficult to parse the code in the first place. If you can tell me what is the 6th arg passed to Constant (and replace the `default_value: str` accordingly), I would appreciate it .

In any case, it seems to not be using this arg anyway, so this doesn't change anything either way.

let me know if you'd like me to change something more.