### PR TITLE
Preserve leading whitespaces in the docstrings' description

### DIFF
--- a/gdscript_docs_maker/modules/gdscript_objects.py
+++ b/gdscript_docs_maker/modules/gdscript_objects.py
@@ -69,7 +69,7 @@ Metadata should be of the form key: value, e.g. category: Category Name
         elif match_category:
             category = match_category.group(1)
         else:
-            description_trimmed.append(line.strip())
+            description_trimmed.append(re.sub(r'^ ([^\s])',r'\g<1>',line))
 
     metadata: Metadata = Metadata(tags, category)
     return "\n".join(description_trimmed), metadata

--- a/gdscript_docs_maker/modules/gdscript_objects.py
+++ b/gdscript_docs_maker/modules/gdscript_objects.py
@@ -69,7 +69,7 @@ Metadata should be of the form key: value, e.g. category: Category Name
         elif match_category:
             category = match_category.group(1)
         else:
-            description_trimmed.append(re.sub(r'^ ([^\s])',r'\g<1>',line))
+            description_trimmed.append(re.sub(r'^ ([^\s])',r'\g<1>',line).rstrip())
 
     metadata: Metadata = Metadata(tags, category)
     return "\n".join(description_trimmed), metadata

--- a/gdscript_docs_maker/modules/gdscript_objects.py
+++ b/gdscript_docs_maker/modules/gdscript_objects.py
@@ -69,7 +69,7 @@ Metadata should be of the form key: value, e.g. category: Category Name
         elif match_category:
             category = match_category.group(1)
         else:
-            description_trimmed.append(re.sub(r'^ ([^\s])',r'\g<1>',line).rstrip())
+            description_trimmed.append(re.sub('^ ', '', line).rstrip())
 
     metadata: Metadata = Metadata(tags, category)
     return "\n".join(description_trimmed), metadata


### PR DESCRIPTION
- [ ] The commit message follows our guidelines.
- For bug fixes and features:
    - [x] You tested the changes.
    - [ ] You updated the docs or changelog.


Closes #68

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**

When docstring has more than 1 leading whitespace, then they will be preserved as whitespaces are used in markdown for various purposes, such as nested lists

**Does this PR introduce a breaking change?**

No

**What is the current behavior?** 

Currently it strips all leading whitespace, which means markdown nested lists don't work correctly. Probably other markdown using indentation is affected.
