### PR TITLE
Remove set -x

### DIFF
--- a/generate_reference
+++ b/generate_reference
@@ -1,5 +1,4 @@
 #!/usr/bin/env sh
-set -x
 
 project_directory="$1"
 output_directory="export"


### PR DESCRIPTION
In #63 I wrote (https://github.com/GDQuest/gdscript-docs-maker/issues/63#issuecomment-751374542) that removing `set -x` fixes the generation of the `reference.json` file. 

I'm not sure if this is a side effect or what, but I'm creating this to have a minimal diff to link in the issue.

---

- [x] The commit message follows our guidelines.
- For bug fixes and features:
    - [ ] You tested the changes.
    - [ ] You updated the docs or changelog.
