### PR TITLE
Assume the file name for a class if no class_name is given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This document lists new features, improvements, changes, and bug fixes in every GDScript docs maker release.
 
+## GDScript Docs Maker 1.6.0
+
+### New Features
+
+- If a GDScript file does not use class_name, the name of that file is now used as the class name to include previously not documented files
+
 ## GDScript Docs Maker 1.5.1
 
 ### Bug fixes

--- a/godot-scripts/Collector.gd
+++ b/godot-scripts/Collector.gd
@@ -85,6 +85,8 @@ func get_reference(files := PoolStringArray(), refresh_cache := false) -> Dictio
 		if refresh_cache:
 			workspace.parse_local_script(file)
 		var symbols: Dictionary = workspace.generate_script_api(file)
+		if symbols["name"] == "":
+			symbols["name"] = file.get_file()
 		data["classes"].append(symbols)
 	return data
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [X] The commit message follows our guidelines.
- For bug fixes and features:
    - [X] You tested the changes.
    - [X] You updated the docs or changelog.

**What kind of change does this PR introduce?**

If a GDScript file doesn't use class_name (for example, Singletons), the name of the file is now assumed as the class name. This enables the documentation of all other files.

**Does this PR introduce a breaking change?**

Not a breaking change per se, but the generated documentation now includes all non-classes and will generate way more files.

## New feature or change ##


**What is the current behavior?** 

Files that don't use class_name are left out of the documentation (or rather are generated into the file ".md" repitetively)

**What is the new behavior?**

All GDScript files are documented. The ones, that don't include class_name are named after the file name.

**Other information**

I assumed a version 1.6.0 in the changelog to comply with semver because it behaves differently than before because of the change.