### PR TITLE
fix: Use password for description step instead of token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,6 @@ jobs:
                 uses: peter-evans/dockerhub-description@v2
                 with:
                     username: ${{ secrets.DOCKER_USERNAME }}
-                    password: ${{ secrets.DOCKER_TOKEN }}
+                    password: ${{ secrets.DOCKER_PASSWORD }}
                     repository: gdquest/gdscript-docs-maker
 


### PR DESCRIPTION
This is a fix for the github workflow not completing successfully.

It requires, that a new secret is added called `DOCKER_PASSWORD` that is set to the actual password used to signup to docker hub as the access token can't be used for the failing step. :/