### PR TITLE
Exclude warning-ignore comments when generating reference

### DIFF
--- a/godot-scripts/Collector.gd
+++ b/godot-scripts/Collector.gd
@@ -1,16 +1,16 @@
+# Finds and generates a code reference from gdscript files.
 tool
 extends SceneTree
-# Finds and generates a code reference from gdscript files.
 
-var warnings_regex: RegEx
+var warnings_regex := RegEx.new()
+
 
 func _init() -> void:
-	warnings_regex = RegEx.new()
-	
 	var pattern := "^\\s?(warning-ignore(-all|):\\w+|warnings-disable)\\s*$"
 	var error := warnings_regex.compile(pattern)
 	if error != OK:
-		printerr("Failed to compile '%s' to a regex pattern" % pattern)
+		printerr("Failed to compile '%s' to a regex pattern." % pattern)
+
 
 # Returns a list of file paths found in the directory.
 #
@@ -99,30 +99,31 @@ func get_reference(files := PoolStringArray(), refresh_cache := false) -> Dictio
 		var symbols: Dictionary = workspace.generate_script_api(file)
 		if symbols.has("name") and symbols["name"] == "":
 			symbols["name"] = file.get_file()
-		clean_symbols(symbols)
+		remove_warning_comments(symbols)
 		data["classes"].append(symbols)
 	return data
 
-# Takes a dictionary of code reference data and normalize it 
-# like stripping off 'warning-ignore' comments
-func clean_symbols(symbols: Dictionary) -> void:
-	if not warnings_regex.is_valid():
-		return
-	symbols["description"] = clean_description(symbols["description"])
+
+# Directly removes 'warning-ignore', 'warning-ignore-all', and 'warning-disable'
+# comments from all symbols in the `symbols` dictionary passed to the function.
+func remove_warning_comments(symbols: Dictionary) -> void:
+	symbols["description"] = remove_warnings_from_description(symbols["description"])
 	for meta in ["constants", "members", "signals", "methods", "static_functions"]:
 		for metadata in symbols[meta]:
-			metadata["description"] = clean_description(metadata["description"])
+			metadata["description"] = remove_warnings_from_description(metadata["description"])
 	
 	for sub_class in symbols["sub_classes"]:
-		clean_symbols(sub_class)
+		remove_warning_comments(sub_class)
 
-func clean_description(description: String) -> String:
+
+func remove_warnings_from_description(description: String) -> String:
 	var lines := description.strip_edges().split("\n")
 	var clean_lines := PoolStringArray()
 	for line in lines:
 		if not warnings_regex.search(line):
 			clean_lines.append(line)
 	return clean_lines.join("\n")
+
 
 func print_pretty_json(reference: Dictionary) -> String:
 	return JSON.print(reference, "  ")


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.
- For bug fixes and features:
    - [x] You tested the changes.
    - [ ] You updated the docs or changelog.


Related issue: #90 

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**

Remove `warning-ignore:warning_id`, `warning-ignore-all:warning_id` and `warnings-disable` from doc-strings.

**Does this PR introduce a breaking change?**

No it doesn't so far, however generating the reference takes slightly longer.


## New feature or change ##


**What is the current behavior?** 

All type of inline comments are included into the doc string

**What is the new behavior?**

Excluding warning ignore comments from doc-string lines if they form a valid `warning-ignore` based on how the Godot editor treats them.
```gdscript
"valid warning suppression comments"
# warning-ignore:warning_id
# warning-ignore-all:warning_id
# warning-disable

"these ones aren't valid and will be kept in the doc-string"
# warning-ignore:warning_id some text after
# some text before warning-ignore:warning_id
#  warning-ignore:warning_id (notice the spacing)
```
