### PR TITLE
Workaround `generate_reference` error in Godot 4.2.x

### DIFF
--- a/godot-scripts/ReferenceCollectorCLIGd4.gd
+++ b/godot-scripts/ReferenceCollectorCLIGd4.gd
@@ -12,7 +12,7 @@ var is_recursive: = true
 var patterns := ["*.gd"]
 
 
-func _init() -> void:
+func _initialize() -> void:
 	var files := PackedStringArray()
 	for dirpath in directories:
 		files.append_array(Collector.find_files(dirpath, patterns, is_recursive))


### PR DESCRIPTION
Fixes #95

See also: https://github.com/godotengine/godot/issues/86132



**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.
- For bug fixes and features:
    - [x] You tested the changes.


Related issue (if applicable):

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**
See Godot issue 86132


**Does this PR introduce a breaking change?**
Unknown


## New feature or change ##


**What is the current behavior?** 


**What is the new behavior?**



**Other information**
